### PR TITLE
Fix type of tree node metadata.

### DIFF
--- a/transmart_loader/transmart.py
+++ b/transmart_loader/transmart.py
@@ -329,7 +329,7 @@ class TreeNodeMetadata:
     """
     Metadata tags
     """
-    def __init__(self, values: Dict[str, Value]):
+    def __init__(self, values: Dict[str, str]):
         self.values = values
 
 


### PR DESCRIPTION
The type used here (`Value`) is not compatible with what is assumed in `copy_writer.py`. The writer assumes the values to be `str`.